### PR TITLE
Remove path to mkUnicodeTestData. While specifying at path using CMAK…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ if( _useUnitTests )
   target_link_libraries( mkUnicodeTestData PRIVATE ansakString )
 
   add_custom_command( OUTPUT "${PROJECT_BINARY_DIR}/char_is_unicode_test_data.hxx"
-              COMMAND "${CMAKE_CFG_INTDIR}/mkUnicodeTestData"
+              COMMAND "mkUnicodeTestData"
                       "${absBitsDir}/UnicodeData.txt"
                       "${PROJECT_BINARY_DIR}/char_is_unicode_test_data.hxx"
                       COMMENT "Generating test data for charIsUnicode test"


### PR DESCRIPTION
…E_CFG_INTDIR would seem like the right thing to do, it fails in the case where the binary output directory has been set to something other than the default cmake location (this is the case with our client software). By removing the path we allow cmake to simply 'do the right thing' and find the binary in whatever location it was built. If there is a path it will only look down the path.